### PR TITLE
fix: update MeshLine to MeshLineGeometry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Meshline can be used declaritively in [react-three-fiber](https://github.com/pmn
 import { Canvas, extend } from '@react-three/fiber'
 import { MeshLineGeometry, MeshLineMaterial, raycast } from 'meshline'
 
-extend({ MeshLine, MeshLineMaterial })
+extend({ MeshLineGeometry, MeshLineMaterial })
 
 function App() {
   return (


### PR DESCRIPTION
MeshLine is renamed to MeshLineGeometry in pmdrs/meshline.