### PR TITLE
BUG: _attributes.position.count will always be unequal to positions.length

### DIFF
--- a/src/MeshLineGeometry.ts
+++ b/src/MeshLineGeometry.ts
@@ -225,7 +225,7 @@ export class MeshLineGeometry extends THREE.BufferGeometry {
     this.next.push(v[0], v[1], v[2])
     this.next.push(v[0], v[1], v[2])
 
-    if (!this._attributes || this._attributes.position.count !== this.positions.length) {
+    if (!this._attributes || this._attributes.position.count !== this.counters.length) {
       this._attributes = {
         position: new THREE.BufferAttribute(new Float32Array(this.positions), 3),
         previous: new THREE.BufferAttribute(new Float32Array(this.previous), 3),


### PR DESCRIPTION
I came across this bug because i was seeing major GC events in chrome while using this library, and it would cause the render to lock up every 5-10 seconds.

I am currently updating several meshlines by calling setPoints() on each frame and i appears that due to this inequality check, each call to setPoints was redefining this._attributes and thus creating new THREE.BufferAttribute's for each attribute. (please note that the number of points for each line was static)

From what I can tell it appears that this.counters.length would be the correct reference to check against to see if the point count has changed.

If I am in error, please let me know.

Thanks for maintaining this library and many others!