### PR TITLE
Swap encodings_fragment for colorspace_fragment due to it being deprecated in Three r154

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshline",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "author": "Jaume Sanchez <the.spite@gmail.com> (https://www.clicktorelease.com)",
   "license": "MIT",
   "bugs": {
@@ -29,7 +29,7 @@
     "vite": "^3.2.5"
   },
   "peerDependencies": {
-    "three": ">=0.137"
+    "three": ">=0.154"
   },
   "scripts": {
     "dev": "vite demo",

--- a/src/MeshLineMaterial.ts
+++ b/src/MeshLineMaterial.ts
@@ -108,7 +108,7 @@ const fragmentShader = /* glsl */ `
     gl_FragColor.a *= step(vCounters, visibility);
     #include <fog_fragment>
     #include <tonemapping_fragment>
-    #include <encodings_fragment>
+    #include <colorspace_fragment>
   }
 `
 


### PR DESCRIPTION
encodings_fragment is deprecated in Three r154. The direct replacement is colorspace_fragment

Bumped versions in package.json too but I am no package dev so needs reviewing. This would make it compatible with threejs r154

If possible, best solution would be to check what version of `Three` that is used and then do `#include encodings/colorspace_fragment` depending on the result. Not sure if this is possible though?