### PR TITLE
Geometry "last next point" results in NaN vertices due to reading outside of the array

### DIFF
--- a/src/MeshLineGeometry.ts
+++ b/src/MeshLineGeometry.ts
@@ -224,11 +224,20 @@ export class MeshLineGeometry extends THREE.BufferGeometry {
     if (this.compareV3(l - 1, 0)) {
       v = this.copyV3(1)
     } else {
+      // Below code will result in NaNs if the value of 'l' is less than 9 (rightmost last this.positions read 9-3-6 = 0 most restrictive)
+      // Not sure how this should be fixed but some kind of check and handling needs to be done
       v = [
         this.positions[l - 1] + (this.positions[l - 1] - this.positions[l - 1 - 6]),
         this.positions[l - 2] + (this.positions[l - 2] - this.positions[l - 2 - 6]),
         this.positions[l - 3] + (this.positions[l - 3] - this.positions[l - 3 - 6])
       ]
+
+      //Furthermore can be simplified to (+ error handling needed) -->
+      // v = [
+      //   2 * this.positions[l - 1] - this.positions[l - 1 - 6],
+      //   2 * this.positions[l - 2] - this.positions[l - 2 - 6],
+      //   2 * this.positions[l - 3] - this.positions[l - 3 - 6]
+      // ]
     }
     this.next.push(v[0], v[1], v[2])
     this.next.push(v[0], v[1], v[2])


### PR DESCRIPTION
The fork has disabled issues so I am creating a "dummy" PR to make you aware of this issue.

In our case, our `this.positions` is of length 12 --> ´l = 2`
If you look at the place where I have added comments in the code, you can see that there is a clear issue for us when we try to read from the array at position `l - 3 (2 - 3)` and even worse, as you can see, `l - 3 -6 (2 - 3 - 6)` . There are obvious out of bounds errors made.

As a "workaround" I created my own for where I reverted the commit that changed this behaviour (3244cda5c9dd781f667e7fef95b0cae7a2de9246). This is sufficient for our use-case, but obviously we would like to use this "semi official" package through NPM rather than our own temporary fork on GH.

Any ideas on how this could be fixed? I can do it myself if you wish, I am just a bit unsure how it is meant as it is vastly different compared to the earlier version before the shader was changed.

Cheers